### PR TITLE
Rewrite the host header to satisfy mitmweb

### DIFF
--- a/mitmproxy/root/etc/haproxy/haproxy.cfg
+++ b/mitmproxy/root/etc/haproxy/haproxy.cfg
@@ -59,4 +59,5 @@ frontend main
 
 backend mitmweb
     balance     roundrobin
+    http-request set-header Host 127.0.0.1:9090
     server  mitm    127.0.0.1:9090 check


### PR DESCRIPTION
Fix an issue where mitmweb complained about DNS rebinding risk.

This occurred when connecting to he HA instance using a hostname of anything *other* than a numerical IP address or localhost.

The text style hostname would trigger a warning against DNS rebinding, where mitmweb was trying to protect the user against malicious users interfering with traffic between the client and mitmweb itself.

In this case the traffic is connecting via an ingress route run by HA itself; the hostname we are connecting to is almost irrelevant because the actual connection is being made between containers run by the supervisor.

Since we already have haproxy running, we can rewrite the header to always connect to 127.0.0.1:9090, which is where the mitmweb server lives.

In theory, someone operating a mitm proxy between the user and the HA instance could interfere with the connection including the view of mitmweb.  But if they were successful at intercepting this traffic, they would have the users username and password anyway, and could make their own connection to the mitmweb instance.

In summary, modifying the config for haproxy fixes this issue, and does not expose the user to any new risks that I'm aware of.

fixes #29 