### PR TITLE
Update to 1.3.2

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -51,8 +51,8 @@ jobs:
 
           if [[ -n ${changed} ]]; then
             echo "Changed add-ons: $changed";
-            echo "::set-output name=changed::true";
-            echo "::set-output name=addons::[$changed]";
+            echo "changed=true" >> $GITHUB_OUTPUT;
+            echo "addons=[$changed]" >> $GITHUB_OUTPUT;
           else
             echo "No add-on had any monitored files changed (${{ env.MONITORED_FILES }})";
           fi
@@ -80,14 +80,14 @@ jobs:
         id: check
         run: |
           if [[ "${{ steps.info.outputs.architectures }}" =~ ${{ matrix.arch }} ]]; then
-             echo "::set-output name=build_arch::true";
-             echo "::set-output name=image::$(echo ${{ steps.info.outputs.image }} | cut -d'/' -f3)";
+             echo "build_arch=true" >> $GITHUB_OUTPUT;
+             echo "image=$(echo ${{ steps.info.outputs.image }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT;
              if [[ -z "${{ github.head_ref }}" ]] && [[ "${{ github.event_name }}" == "push" ]]; then
                  echo "BUILD_ARGS=" >> $GITHUB_ENV;
              fi
            else
              echo "${{ matrix.arch }} is not a valid arch for ${{ matrix.addon }}, skipping build";
-             echo "::set-output name=build_arch::false";
+             echo "build_arch=false" >> $GITHUB_OUTPUT;
           fi
 
       - name: Login to GitHub Container Registry

--- a/mitmproxy/CHANGELOG.md
+++ b/mitmproxy/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.2 - 2023-10-19
+
+- 📝 Attempt to fix 'manifest unknown' problem with build.
+- 📝 Fix some github build warnings
+
 ## 1.3.1 - 2023-10-18
 
 - 📝 Fixed issue #29 where mitmproxy would display 403 error about DNS Rebinding
@@ -7,11 +12,10 @@
 - 📝 Reinstated mitmproxy following deprecation by Poeschl
 - 🔼 Updated container base images to `3.18`
 - 🔼 Updated haproxy to `2.7.6.r10`
-- 🔼 Updated mitmproxy to `10.1.1-r0` 
+- 🔼 Updated mitmproxy to `10.1.1-r0`
 - 📝 Added patching of mitmweb to allow ingress
 - 📝 Port 8081 is no longer exposed for UI access - removed from config UI
 - 📝 Updated readme, documentation etc to reflect new/old maintainers.
-
 
 ## 1.2.0 - 2022-04-05
 

--- a/mitmproxy/config.yaml
+++ b/mitmproxy/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: mitmproxy
-version: "1.3.1"
+version: "1.3.2"
 slug: mitmproxy
 description: >-
   A free and open source interactive HTTPS proxy for intercepting and inspecting network traffic.


### PR DESCRIPTION
Mostly this version bump is to trigger a rebuild, as attempting to install 1.3.1 currently produces this error:

_Can't install ghcr.io/davet2001/aarch64-addon-mitmproxy:1.3.1: 500 Server Error for http+docker://localhost/v1.42/images/create?tag=1.3.1&fromImage=ghcr.io%2Fdavet2001%2Faarch64-addon-mitmproxy&platform=linux%2Farm64: Internal Server Error ("manifest unknown")_