### PR TITLE
Fix options update

### DIFF
--- a/mitmproxy/Dockerfile
+++ b/mitmproxy/Dockerfile
@@ -55,7 +55,7 @@ RUN pip3 install --no-cache-dir --user --upgrade mitmproxy==10.1.1
 COPY mitmweb_relpath.patch /mitmweb_relpath.patch
 RUN patch -u /root/.local/lib/python3.11/site-packages/mitmproxy/tools/web/templates/index.html -i /mitmweb_relpath.patch
 RUN sed -i 's/"\/updates\"/location\.pathname\+"updates"/' /root/.local/lib/python3.11/site-packages/mitmproxy/tools/web/static/app.js
-
+RUN sed -i 's/"\/options/"options/' /root/.local/lib/python3.11/site-packages/mitmproxy/tools/web/static/app.js
 FROM $BUILD_FROM AS RUNNING
 
 RUN apk add --no-cache \

--- a/mitmproxy/root/etc/haproxy/haproxy.cfg
+++ b/mitmproxy/root/etc/haproxy/haproxy.cfg
@@ -27,7 +27,6 @@ global
     log         127.0.0.1 local2
 
     chroot      /var/lib/haproxy
-    pidfile     /var/run/haproxy.pid
     maxconn     4000
     user        haproxy
     group       haproxy

--- a/mitmproxy/root/etc/haproxy/haproxy.cfg
+++ b/mitmproxy/root/etc/haproxy/haproxy.cfg
@@ -58,5 +58,8 @@ frontend main
 
 backend mitmweb
     balance     roundrobin
-    http-request set-header Host 127.0.0.1:9090
+    # removing this next line fixes problems with options live edit.
+    # but causes a gateway error if the client is connecting via a domain
+    # rather than an IP.
+    #http-request set-header Host 127.0.0.1:9090
     server  mitm    127.0.0.1:9090 check


### PR DESCRIPTION
Make the options update at least work via the UI rather than autodelete everything straight after you type it.

But fixing this reintroduces the problem where mitmweb warns about dns rebind attacks if it doesn't see a client connecting to it via an IP