### PR TITLE
Fix hostname based access

### DIFF
--- a/mitmproxy/CHANGELOG.md
+++ b/mitmproxy/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.3 - 2023-10-21
+
+- 📝 Fix websocket problem where options would disappear as soon as you typed them in the web UI
+- 📝 Tidy up some log output
+- 📝 Update developer docs
+
 ## 1.3.2 - 2023-10-19
 
 - 📝 Attempt to fix 'manifest unknown' problem with build.

--- a/mitmproxy/DOCS.md
+++ b/mitmproxy/DOCS.md
@@ -1,6 +1,6 @@
 # Web UI
 
-To access the user interface of mitmproxy, click 'open web UI' from the addon info page.  
+To access the user interface of mitmproxy, click 'open web UI' from the addon info page.
 This connects to the 'mitmweb' service running within the addon.
 
 # Configuration
@@ -20,7 +20,7 @@ options:
 
 The list with all possible settings can be found [here](https://docs.mitmproxy.org/stable/concepts-options/#available-options).
 
-It is possible to modify settings via the user interface, but these are not 
+It is possible to modify settings via the user interface, but these are not
 currently saved between restarts of the mitmproxy addon.
 
 If you need to write into a file, the `/share` folder is mapped into the addon.
@@ -53,7 +53,7 @@ There are also a few settings which are fixed to their values. Those are:
 - `listen_port`
 - `confdir`
 
-*Note that the listen port is configured as `8080` by default, this is the proxy server where the clients make their connection.  Changing the setting in the addon config re-maps the internal port 8080 to the external port specified.  mitmweb is unaware that this remapping is taking place, so it still displays `HTTP(S) proxy listening at *:8080`, regardless of what the external port setting is.  Please ignore the '8080' shown on the mitmweb in this case.*
+_Note that the listen port is configured as `8080` by default, this is the proxy server where the clients make their connection. Changing the setting in the addon config re-maps the internal port 8080 to the external port specified. mitmweb is unaware that this remapping is taking place, so it still displays `HTTP(S) proxy listening at _:8080`, regardless of what the external port setting is. Please ignore the '8080' shown on the mitmweb in this case.\*
 
 # Onboarding
 
@@ -62,3 +62,23 @@ To install the mitmproxy certificate authority as a trusted CA, the onboarding p
 Follow the instructions on the page to install these to your device.
 
 Notice that your traffic must be routed over mitmproxy to access the page.
+
+# Development
+
+Debugging and developing mitmproxy can be challenging when inside a container, especially the link between haproxy and mitmweb which can be hard to log and debug.
+
+The following commands help expose this interaction to be running directly on the develoment machine. Each should be run in a parallel separate terminal.
+
+Set up mitmproxy to expose the interception proxy port on 9080, and expose the web UI on 9090:
+`docker run --rm -it -p 9080:8080 -p 9090:8081 mitmproxy/mitmproxy mitmweb --web-host 0.0.0.0`
+
+Set up haproxy to run listenning on port 8082, mapping to 8081
+`docker run -p 8082:8081 -v /home/dave/dev/home-assistant-addons/mitmproxy/root/etc/haproxy:/usr/local/etc/haproxy:ro --sysctl net.ipv4.ip_unprivileged_port_start=0 haproxy:2.3`
+
+Explanation: the connection is then made in the following siquence
+
+- web browser views http://localhost:8082
+- (haproxy container:8082, mapped to internal :8081 )
+- haproxy config file then defines the reverse proxy redirect 8081 to localhost:9090
+- (mitmproxy mitmweb conatiner running on localhost:9090, mapped to internal: 8081 port serving web page)
+- user sees content from mitmweb on their browser.

--- a/mitmproxy/config.yaml
+++ b/mitmproxy/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: mitmproxy
-version: "1.3.2"
+version: "1.3.3"
 slug: mitmproxy
 description: >-
   A free and open source interactive HTTPS proxy for intercepting and inspecting network traffic.

--- a/mitmproxy/root/etc/haproxy/haproxy.cfg
+++ b/mitmproxy/root/etc/haproxy/haproxy.cfg
@@ -44,7 +44,7 @@ defaults
     log                     global
     option                  dontlognull
     option http-server-close
-    option forwardfor       except 127.0.0.0/8
+    #option forwardfor       except 127.0.0.0/8
     timeout connect         10s
     timeout client          1m
     timeout server          1m
@@ -58,8 +58,6 @@ frontend main
 
 backend mitmweb
     balance     roundrobin
-    # removing this next line fixes problems with options live edit.
-    # but causes a gateway error if the client is connecting via a domain
-    # rather than an IP.
-    #http-request set-header Host 127.0.0.1:9090
+    http-request set-header Host 127.0.0.1:9090
+    http-request set-header Origin http://127.0.0.1:9090
     server  mitm    127.0.0.1:9090 check

--- a/mitmproxy/root/etc/services.d/mitmproxy/run
+++ b/mitmproxy/root/etc/services.d/mitmproxy/run
@@ -6,8 +6,7 @@ OPTIONS=$(bashio::jq "${CONFIG_PATH}" 'with_entries(if .value == "" then empty e
 bashio::log.info "Extraction complete."
 bashio::log.info "Start mitmproxy with options: $OPTIONS"
 HOST=$(bashio::host.hostname)
-HOSTINFO=$(bashio::host)
-bashio::log.info "${HOSTINFO}"
+bashio::log.info "Hostname is ${HOST}"
 
 bashio::log.info "For the onboarding page, configure web client to use proxy ${HOST}:8080, then visit the magic url http://mitm.it which mitmweb will intercept and give you a root certificate download page for your client."
 # shellcheck disable=SC2086
@@ -18,6 +17,3 @@ mitmweb $OPTIONS \
   --set 'confdir=/data/mitmproxy' \
   --set 'web_open_browser=false' \
   --no-web-open-browser
-
-#  --set 'onboarding_port=8082' \
-#  --set "onboarding_host=$HOST" \


### PR DESCRIPTION
Ingress mode was working before but there was a problem with the webproxy connection which resulted in options immediately being deleted as soon as each character was typed.

This is was a balance between two things:

1. mitmproxy tries to protect against DNS rebinding.  This means it rejects any connections to mitmproxy that are not made by IP address.  Since connections to the addon are usually made via `homeassistant.local` or similar, this resulted in all connections being rejected.

2. mitmproxy (actually its built in tornado webserver) has same origin protection for websockets.  If you leave all the headers untampered, the connection works ok.  But because of 1. above, this only works when connecting via IP address.

Rewriting the http headers as the traffic transits through haproxy solves 1. (also necessary to remove the header constraint to block running in an HTML frame).  But there was a problem in how this was being done, which resulted in websocket connections failing 2.

Ultimately it was just a small edit to the haproxy config file.

The method of tracing down was to run both haproxy and mitmproxy in separate docker containers on the development machine, and use wireshark to watch traffic from the web client through each docker container, seeing the headers change each time.